### PR TITLE
chore(release): Use last-release-git

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.0",
     "karma-typescript": "3.0.2",
+    "last-release-git": "^0.0.3",
     "node-fetch": "^1.6.3",
     "semantic-release": "^6.3.2",
     "ts-node": "^3.0.0",
@@ -48,5 +49,8 @@
     "precommit": "npm run lint -s",
     "commitmsg": "validate-commit-msg",
     "prepush": "npm run lint -s && npm run build -s"
+  },
+  "release": {
+    "getLastRelease": "last-release-git"
   }
 }


### PR DESCRIPTION
Since we have option to use gemfury, npmjs and github, they might not be in sync

We can use last-release-git to get last tag which will behave as our single source of truth and will publish
the same version to npm too.