### PR TITLE
test(mockMiddleware): use fake timers

### DIFF
--- a/src/middlewares/MockMiddleware.spec.ts
+++ b/src/middlewares/MockMiddleware.spec.ts
@@ -126,7 +126,7 @@ describe("MockMiddleware", () => {
             MockMiddleware.resolvingPromise({ mock: true }, 50).then(spy);
             jest.advanceTimersByTime(49);
             expect(spy).not.toHaveBeenCalled();
-            jest.advanceTimersByTime(51);
+            jest.advanceTimersByTime(1);
             // this is required because even though it's advanced by time, Promise is on kinda background, we need to kick off promise chain
             await Promise.resolve();
             expect(spy).toHaveBeenCalled();


### PR DESCRIPTION
now that we're using fake timers it might run tiny bit faster (shouldn't be noticable), but there's a kinda trick in this thing, I'll create a issue to follow up with https://github.com/facebook/jest/issues/2157 and we can do it non dirty way.

closes #161 