### PR TITLE
chore(dependabot): enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(packages): "
+    labels:
+      - "npm"
+      - "dependabot"


### PR DESCRIPTION
normally dependabot only sends PR for security stuff, but if we explicitly enable it using dependabot.yml, it'll also send updates for other types of updates.

Hopefully merging this will trigger some PRs, and we can remove snyk.io :hand_over_mouth: 