### PR TITLE
ci(dependabot): enable dependabot for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
       - "npm"
       - "dependencies"
     open-pull-requests-limit: 10
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/docs" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build(deps): "
+    labels:
+      - "npm"
+      - "dependencies"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
closes #255 
closes #256 
closes #257 
closes #260 

I prefer closing them, disabling them, then just let dependabot work for us from now on 🙂 

While we're on that let's find out how to disable snyk from creating any further PRs (maybe can be done from repo settings)